### PR TITLE
Config linter e imports con @

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,14 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'semi': ['error', 'never'],
+      'no-restricted-imports': [
+        'error',
+        {
+          "patterns": [{ "regex": "^@mui/[^/]+$" }]
+        }
+      ]
+    },
   },
 ])

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,7 +22,14 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: { 
+    alias: { 
+      "@": path.resolve(__dirname, "./src"), 
+    }, 
+  },
 })


### PR DESCRIPTION
- La regla `semi: ['error', 'never']` debería marcar como error el uso de ; en el código y sale como error al ejecutar el linter.
- Se agregar regla para imports de MUI para evitar imports que aumenten innecesariamente el [bundle size](https://mui.com/material-ui/guides/minimizing-bundle-size/#enforce-best-practices-with-eslint).
- Se configura alias para usar imports con @ en `tsconfig.app.json` y se modifica `vite.config.ts` para que el bundler pueda procesar los imports correctamente.

Resolves #6 